### PR TITLE
fix: 在攻击者落后K个区块情况下，能够成功发动51%攻击的概率计算问题

### DIFF
--- a/Bitcoin-Whitepaper-EN-CN.md
+++ b/Bitcoin-Whitepaper-EN-CN.md
@@ -215,7 +215,7 @@ $$
 
 To get the probability the attacker could still catch up now, we multiply the Poisson density for each amount of progress he could have made by the probability he could catch up from that point:
 
-为了算出攻击者依然可以赶上的概率，我们要把每一个攻击者已有的进展的帕松密度乘以他可以从那一点能够追上来的概率：
+为了算出攻击者依然可以赶上的概率，我们要把攻击者需要追赶的区块数目的帕松分布概率密度，乘以在落后该区块数目下能够追上来的概率：
 
 $$
 \large \sum_{k=0}^{\infty} \frac{\lambda^k e^{-\lambda}}{k!} \cdot


### PR DESCRIPTION
原翻译：**为了算出攻击者依然可以赶上的概率，我们要把每一个攻击者已有的进展的帕松密度乘以他可以从那一点能够追上来的概率**：

这里的"每一个攻击者"的翻译容易造成误解，中本聪论文的原意是“攻击者在落后k个区块时能够赶上诚实链条，发动 51%攻击的概率计算”，这里的"each amount of progress"是指落后k(1,2,3,4....)个区块的每一种概率计算，最后能够发动51%攻击的总概率即是 落后k(1,2,3,4...)个区块的所有情况的概率统计值，翻译成"每一个攻击者"有偏差，容易让人理解为好多攻击者共同发动的51%攻击，实际上这里探讨的是单个攻击者的行为；

尝试翻译为： **"为了算出攻击者依然可以赶上的概率，我们要把攻击者需要追赶的区块数目的帕松分布概率密度，乘以在落后该区块数目下能够追上来的概率："**